### PR TITLE
Fix: Improve suffix handling in PigLatin

### DIFF
--- a/src/gamesbyexample/piglatin.py
+++ b/src/gamesbyexample/piglatin.py
@@ -53,7 +53,7 @@ def englishToPigLatin(message):
             word = word.title()
 
         # Add the non-letters back to the start or end of the word.
-        pigLatin = pigLatin + prefixNonLetters + word + suffixNonLetters + ' '
+        pigLatin = pigLatin + prefixNonLetters + word + suffixNonLetters[::-1] + ' '
     return pigLatin
 
 


### PR DESCRIPTION
When applying pig latin translation to words like `join()`, the output is `oinjay)(`, since non-letter characters are added to `suffixNonLetters` in the reverse order they appear in the word.

This PR addresses this issue by reversing `suffixNonLetters` through slicing before it is appended to `word`.

The output then becomes the expected `oinjay()`.

---
(Came here from _Automating the boring stuff..._ - great book so far, thoroughly enjoying it!)